### PR TITLE
Remove `mongodb` from `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "bson": "~0.1.8"
   },
   "dependencies": {
-    "mongodb": "~1.3.3",
     "bson": "~0.1.8",
     "to-string": "~0.2.0"
   }


### PR DESCRIPTION
We wanted to use `objectid`, but we needed to remove `mongodb` from the list of dependencies due to licensing issues with it.

I don't think it's needed outside of `devDependencies` (which is okay for us), but let me know if that isn't the case.

Thanks!
